### PR TITLE
display scope without needing to hover

### DIFF
--- a/src/core/components/auth/authorize-operation-btn.jsx
+++ b/src/core/components/auth/authorize-operation-btn.jsx
@@ -19,6 +19,7 @@ export default class AuthorizeOperationBtn extends React.Component {
   render() {
     let { isAuthorized } = this.props
     return (
+      <span>{ this.props.scopes }</span>
       <button className={isAuthorized ? "authorization__btn locked" : "authorization__btn unlocked"}
         aria-label={isAuthorized ? "authorization button locked" : "authorization button unlocked"}
         title={ this.props.scopes }


### PR DESCRIPTION
display scope without needing to hover

### Description
Display scope without needing to hover



### Motivation and Context
So I don't have to hover and wait a few seconds just to see the scope...

### How Has This Been Tested?
Testing, what's that?


### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [X] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [X] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [X] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
