### PR TITLE
Center background image

### DIFF
--- a/dist/esi.css
+++ b/dist/esi.css
@@ -10,12 +10,8 @@ html {
 
 body {
   margin:0;
-  background: #111;
   font-family: "Roboto", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
-  background-image: url("background.jpg");
-  background-repeat: no-repeat;
-  background-attachment: fixed;
-  background-size: cover;
+  background: #111 url(background.jpg) center/cover fixed;
 }
 
 .swagger-ui .topbar {


### PR DESCRIPTION
Centered the background image, as it looked awkward when running the UI on only half a screen.
Also replaced the separate properties with a shorthand one.